### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Anime module for Nuxt.
 1. Install `@hypernym/nuxt-anime` to your project
 
 ```sh
-npm i -D @hypernym/nuxt-anime
+npx nuxi@latest module add animejs
 ```
 
 2. Enable the module in the main config file

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Anime module for Nuxt.
 1. Install `@hypernym/nuxt-anime` to your project
 
 ```sh
+npm i -D @hypernym/nuxt-anime
+
+# or via nuxi
 npx nuxi@latest module add animejs
 ```
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->

## Type of Change

<!-- Check the boxes with an 'x' that refers to your changes. -->

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Breaking change
- [ ] Tests
- [ ] Other

## Request Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


## Additional Details

<!-- Provide additional information if necessary. Otherwise, feel free to skip this section. -->
